### PR TITLE
add "STREAM Receipts" docs to Specs

### DIFF
--- a/src/_data/specs.yml
+++ b/src/_data/specs.yml
@@ -60,6 +60,12 @@
     permalink: /rfcs/0036-spsp-pull-payments/index.html
     src: https://raw.githubusercontent.com/interledger/rfcs/master/0036-spsp-pull-payments/0036-spsp-pull-payments.md
 
+-   name: STREAM Receipts
+    nav: true
+    doc_type: Specs
+    permalink: /rfcs/0039-stream-receipts/index.html
+    src: https://raw.githubusercontent.com/interledger/rfcs/master/0039-stream-receipts/0039-stream-receipts.md
+
 # End Nav
 
 -   name: Payment Pointers


### PR DESCRIPTION
## Description

Adds the doc page for "STREAM Receipts" to the Interledger website, based on https://github.com/interledger/rfcs/blob/master/0039-stream-receipts/0039-stream-receipts.md.

I've added the doc page as the last item in the Specs section -- should it be placed in a particular spot in the list, maybe right after "STREAM Protocol"?

Closes https://github.com/interledger/interledger-website/issues/39

## Localhost demo

https://user-images.githubusercontent.com/25834218/196582026-32ce8708-de9a-40d0-82b5-948c432f54ce.mov