### PR TITLE
Prevent Cognito Form blocking page DOM load

### DIFF
--- a/src/_includes/contact.html
+++ b/src/_includes/contact.html
@@ -6,8 +6,16 @@
       </div>
       <div class="col-12">
         <div class="cognito">
-          <script src="https://www.cognitoforms.com/s/bbN8iw1MJUqjPe6aHn-_rw"></script>
-          <script>Cognito.load("forms", { id: "90" });</script>
+          <script
+            defer
+            onload="loadCognito()"
+            src="https://www.cognitoforms.com/s/bbN8iw1MJUqjPe6aHn-_rw"
+          ></script>
+          <script>
+            function loadCognito() {
+              Cognito.load("forms", { id: "90" });
+            }
+          </script>
         </div>
       </div>
     </div>

--- a/src/_includes/scripts.html
+++ b/src/_includes/scripts.html
@@ -1,3 +1,6 @@
+<!-- preconnect CDN for external resources -->
+<link rel="preconnect" href="https://static.cognitoforms.com" />
+
 <!-- JS Dependencies -->
 <script src="https://code.jquery.com/jquery-3.3.1.slim.min.js" crossorigin="anonymous"></script>
 <script src="https://cdnjs.cloudflare.com/ajax/libs/popper.js/1.14.7/umd/popper.min.js" crossorigin="anonymous"

--- a/src/join/index.html
+++ b/src/join/index.html
@@ -484,8 +484,12 @@ membership_level:
           For Membership Inquiries
         </h2>
         <div class="cognito mt-3">
-          <script src="https://www.cognitoforms.com/s/bbN8iw1MJUqjPe6aHn-_rw"></script>
-          <script>Cognito.load("forms", { id: "90", entry: {Topic: "Membership" }});</script>
+          <script defer onload="loadCognitoMembership()" src="https://www.cognitoforms.com/s/bbN8iw1MJUqjPe6aHn-_rw"></script>
+          <script>
+            function loadCognitoMembership(){
+              Cognito.load("forms", { id: "90", entry: {Topic: "Membership" }});
+            }
+          </script>
         </div>
       </div>
     </div>


### PR DESCRIPTION
I'm trying to resolve issue #42 by making the external script made by the third-party non-blocking (using defer attribute). Also I put a preconnect link on header to reduce slight latency to Cognito's CDN.

I'm currently having trouble setting up local development because my Mac doesn't seem to play nicely with the Ruby version the site is using, so I can't actually test my changes locally on my machine. I need help from others to check if my changes don't break things.